### PR TITLE
Command line flag to resize preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For Arch based users, `fontpreview-ueberzug-git` is available [in AUR](https://a
 ## Usage
 
 ```
-Usage: fontpreview-ueberzug [-h] [-s FONT_SIZE] [-b BG_COLOR] [-f FG_COLOR] [-t PREVIEW_TEXT]
+Usage: fontpreview-ueberzug [-h] [-s FONT_SIZE] [-b BG_COLOR] [-f FG_COLOR] [-t PREVIEW_TEXT] [-p WIDTHxHEIGHT]
 
 Options:
    -h show help message
@@ -34,6 +34,7 @@ Options:
    -b background color
    -f foreground color
    -t preview text
+	 -p preview size (e. g. 640x480)
 ```
 
 ### Tips
@@ -53,6 +54,7 @@ This script makes use of some of the environment variables as follows, these are
 - `FONTPREVIEW_BG_COLOR`: Background color
 - `FONTPREVIEW_FG_COLOR`: Foreground color
 - `FONTPREVIEW_PREVIEW_TEXT`: Preview text to display
+- `FONTPREVIEW_SIZE`: Preview size
 
 ## Difference from [fontpreview](https://github.com/sdushantha/fontpreview)
 

--- a/fontpreview-ueberzug
+++ b/fontpreview-ueberzug
@@ -19,7 +19,7 @@ WIDTH=$(tput cols)
 HEIGHT=$(tput lines)
 
 usage() {
-    echo "Usage: fontpreview-ueberzug [-h] [-s FONT_SIZE] [-b BG] [-f FG] [-t TEXT]"
+    echo "Usage: fontpreview-ueberzug [-h] [-s FONT_SIZE] [-b BG] [-f FG] [-t TEXT] [-p WIDTHxHEIGHT]"
 }
 
 start_ueberzug() {
@@ -47,12 +47,13 @@ preview() {
     printf "action\tremove\tidentifier\t%s\n" "$ID" > "$FIFO"
 }
 
-while getopts "hs:b:f:t:" arg; do
+while getopts "hs:b:f:t:p:" arg; do
     case "$arg" in
         s) FONT_SIZE=$OPTARG;;
         b) BG_COLOR=$OPTARG;;
         f) FG_COLOR=$OPTARG;;
         t) PREVIEW_TEXT=$OPTARG;;
+        p) SIZE=$OPTARG;;
         *) usage; exit ;;
     esac
 done
@@ -67,6 +68,7 @@ if [ "$#" = 0 ]; then
     export FONTPREVIEW_BG_COLOR="$BG_COLOR"
     export FONTPREVIEW_FG_COLOR="$FG_COLOR"
     export FONTPREVIEW_PREVIEW_TEXT="$PREVIEW_TEXT"
+    export FONTPREVIEW_SIZE="$SIZE"
     # The preview command runs this script again with an argument
     convert -list font | sed -n 's/ *Font: //p' | sort | uniq |
     fzf --layout=reverse --preview "sh $0 {}" \


### PR DESCRIPTION
Hello,
I added two minor things that really helped me (I have a small laptop screen and the default size is too big):

 - the command line flag `-p` to resize the preview window on the command line.
 - documentation for it as well as the `$FONTPREVIEW_SIZE` environmental variable.