### PR TITLE
Adjust the width and height to preview window

### DIFF
--- a/fontpreview-ueberzug
+++ b/fontpreview-ueberzug
@@ -16,8 +16,8 @@ abcdefghijklm\nnopqrstuvwxyz\n1234567890\n!@#$\%^&*,.;:\n_-=+'\"|\\(){}[]"}
 FIFO="/tmp/fontpreview-ueberzug-fifo"
 IMAGE="/tmp/fontpreview-ueberzug-img.png"
 ID="fontpreview-ueberzug"
-WIDTH=$(tput cols)
-HEIGHT=$(tput lines)
+WIDTH=$FZF_PREVIEW_COLUMNS
+HEIGHT=$FZF_PREVIEW_LINES
 
 usage() {
     echo "Usage: fontpreview [-h] [-s FONT_SIZE] [-b BG] [-f FG] [-t TEXT]"


### PR DESCRIPTION
From the manpage of fzf:
fzf exports $FZF_PREVIEW_LINES and $FZF_PREVIEW_COLUMNS so that they
represent the exact size of the preview window.
[...]so prefer to refer to the ones with FZF_PREVIEW_ prefix.

This fixes #9